### PR TITLE
feat: trim and check that prefix is not empty

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -249,12 +249,13 @@ export const VSCodeSnippetSettingsModal = (props: {
 
   const save = async () => {
     const snippet = getSnippet()
+    const getTrimedPrefix = () => getPrefix().trim()
 
-    if (!snippet) return
+    if (!snippet || !getTrimedPrefix()) return
 
     await actions.updateSnippet(snippet.id, "vscodeSnippet", {
       ...snippet.vscodeSnippet,
-      prefix: getPrefix(),
+      prefix: getTrimedPrefix(),
     })
   }
 


### PR DESCRIPTION
If the `prefix` is empty, the subsequent synchronization of the `vscode` will not be performed